### PR TITLE
Removed NativeFileDialogs to use Photino built in instead. Fixed swit…

### DIFF
--- a/src/Cyrena.Desktop/Cyrena.Desktop.csproj
+++ b/src/Cyrena.Desktop/Cyrena.Desktop.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="Photino.Blazor" Version="4.0.13" />
-    <PackageReference Include="NativeFileDialogs.Net" Version="1.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cyrena.Desktop/Program.cs
+++ b/src/Cyrena.Desktop/Program.cs
@@ -51,7 +51,7 @@ class Program
             .Load("index.html")
             .Center();
 
-        app.MainWindow.Height = 700;
+        app.MainWindow.Height = 740;
         app.MainWindow.Width = 1000;
         winCurr.SetWindow(app.MainWindow);
 

--- a/src/Cyrena.Desktop/Services/CurrentWindow.cs
+++ b/src/Cyrena.Desktop/Services/CurrentWindow.cs
@@ -10,6 +10,7 @@ namespace Cyrena.Desktop.Services
         public bool Maximized { get; set; }
         public int Width { get; set; } = 1200;
         public int Height { get; set; } = 800;
+        
     }
 
     internal class CurrentWindow : ICurrentWindow
@@ -55,13 +56,13 @@ namespace Cyrena.Desktop.Services
         public void Maximize()
         {
             if (_window == null) return;
-            _window.Maximized = true;
+            _window.SetMaximized(true);
         }
 
         public void Minimize()
         {
             if (_window == null) return;
-            _window.Minimized = true;
+            _window.SetMinimized(true);
         }
 
         public void Restore()
@@ -69,10 +70,24 @@ namespace Cyrena.Desktop.Services
             if (_window == null) return;
             _window.Minimized = false;
             _window.Maximized = _options.Maximized;
-            _window.Height = _options.Height;
-            _window.Width = _options.Width;
             _window.Center();
+            if (_options.Maximized)
+                _window.SetMaximized(true);
+            _window.SetHeight(_options.Height);
+            _window.SetWidth(_options.Width);
             _restored = true;
+        }
+
+        public void SetTransparent(bool b)
+        {
+            if (_window == null) return;
+            _window.SetTransparent(b);
+        }
+
+        public void SetFullScreen(bool b)
+        {
+            if(_window ==null) return;
+            _window.SetFullScreen(b);
         }
 
         public void Dispose()
@@ -85,6 +100,13 @@ namespace Cyrena.Desktop.Services
         private void Save()
         {
             _settings.Save(WindowOptions.Key, _options);
+        }
+
+        public async Task<string[]> ShowFileSelect(string title, string name, string[] filters)
+        {
+            if (_window == null) return [];
+            var files = await _window.ShowOpenFileAsync(title, null, false, [(name, filters)]);
+            return files;
         }
     }
 }

--- a/src/components/Cyrena.Components/Contracts/ICurrentWindow.cs
+++ b/src/components/Cyrena.Components/Contracts/ICurrentWindow.cs
@@ -14,5 +14,8 @@ namespace Cyrena.Contracts
         void Maximize();
 
         void Restore();
+        void SetTransparent(bool b);
+        void SetFullScreen(bool b);
+        Task<string[]> ShowFileSelect(string title, string name, string[] filters);
     }
 }

--- a/src/dotnet/Cyrena.Blazor/Components/Shared/BlazorServerConfig.razor.cs
+++ b/src/dotnet/Cyrena.Blazor/Components/Shared/BlazorServerConfig.razor.cs
@@ -3,12 +3,14 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Cyrena.Blazor.Models;
 using Cyrena.Models;
+using Cyrena.Contracts;
 
 namespace Cyrena.Blazor.Components.Shared
 {
     public partial class BlazorServerConfig : IResultDialog
     {
         [Parameter] public BlazorProject Model { get; set; } = default!;
+        [Inject] private ICurrentWindow _win { get; set;  } = default!;
 
         private EditContext _context = default!;
 
@@ -33,12 +35,10 @@ namespace Cyrena.Blazor.Components.Shared
         {
             try
             {
-                var result = NativeFileDialogs.Net.Nfd.OpenDialog(out var csp);
-
-                if (result == NativeFileDialogs.Net.NfdStatus.Ok)
+                var files = await _win.ShowFileSelect("Choose csproj", "csproj", [".csproj"]);
+                if (files.Length > 0)
                 {
-                    var t = csp;
-                    var info = new FileInfo(t);
+                    var info = new FileInfo(files[0]);
                     Model.RootDirectory = info.DirectoryName ?? string.Empty;
                 }
             }catch (Exception ex)

--- a/src/dotnet/Cyrena.Blazor/Cyrena.Blazor.csproj
+++ b/src/dotnet/Cyrena.Blazor/Cyrena.Blazor.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.2" />
-    <PackageReference Include="NativeFileDialogs.Net" Version="1.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/Cyrena.ClassLibrary/Components/Shared/ClassLibraryConfig.razor.cs
+++ b/src/dotnet/Cyrena.ClassLibrary/Components/Shared/ClassLibraryConfig.razor.cs
@@ -1,16 +1,15 @@
 ﻿using BootstrapBlazor.Components;
 using Cyrena.ClassLibrary.Models;
+using Cyrena.Contracts;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Cyrena.ClassLibrary.Components.Shared
 {
     public partial class ClassLibraryConfig : IResultDialog
     {
         [Parameter] public ClassLibraryProject Model { get; set; } = default!;
+        [Inject] private ICurrentWindow _win { get; set; } = default!;
 
         private EditContext _context = default!;
 
@@ -35,12 +34,10 @@ namespace Cyrena.ClassLibrary.Components.Shared
         {
             try
             {
-                var result = NativeFileDialogs.Net.Nfd.OpenDialog(out var csp);
-
-                if (result == NativeFileDialogs.Net.NfdStatus.Ok)
+                var files = await _win.ShowFileSelect("Choose csproj", "csproj", [".csproj"]);
+                if (files.Length > 0)
                 {
-                    var t = csp;
-                    var info = new FileInfo(t);
+                    var info = new FileInfo(files[0]);
                     Model.RootDirectory = info.DirectoryName ?? string.Empty;
                 }
             }

--- a/src/dotnet/Cyrena.ClassLibrary/Cyrena.ClassLibrary.csproj
+++ b/src/dotnet/Cyrena.ClassLibrary/Cyrena.ClassLibrary.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.2" />
-    <PackageReference Include="NativeFileDialogs.Net" Version="1.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/web/Cyrena.Tavily/Components/Shared/TavilySettings.razor
+++ b/src/web/Cyrena.Tavily/Components/Shared/TavilySettings.razor
@@ -12,12 +12,12 @@
         <InputText @bind-Value="_model.ApiKey" type="password" class="form-control" />
     </div>
 
-    <div class="form-check form-switch mb-3">
-        <InputCheckbox @bind-Value="_model.Enable" class="form-check-input"/>
+    <div class="form-check mb-3">
+        <InputCheckbox @bind-Value="_model.Enable" class="form-check-input" />
         <label class="form-check-label">Enable</label>
     </div>
 
-    <input type="submit" value="Save" class="btn btn-primary btn-sm"/>
+    <input type="submit" value="Save" class="btn btn-primary btn-sm" />
 </EditForm>
 
 @code {


### PR DESCRIPTION
NativeFileDialogs package causes crashes sometimes, Replaced with photino's built in file picker.
Enable swith on tavily settings fixed