### PR TITLE
cyrena.dotnet.csharp 0.5.1

### DIFF
--- a/src/coding/src/dotnet/Cyrena.Dotnet.CSharp/Components/Shared/SolutionSelector.razor
+++ b/src/coding/src/dotnet/Cyrena.Dotnet.CSharp/Components/Shared/SolutionSelector.razor
@@ -1,10 +1,7 @@
 @inherits KernelComponentBase
 
-<div style="width:250px" class="me-1">
-    <select @bind="_sln_id" @bind:after="OnValueChange" disabled="@_its.Inferring" class="form-control form-control-sm">
-        @foreach (var item in _sln.GetValidProjects())
-        {
-            <option value="@item.Id">@item.ProjectName</option>
-        }
-    </select>
-</div>
+<Tooltip Title="Projects">
+    <button type="button" class="btn btn-sm btn-primary rounded-pill me-1 px-2" @onclick="OnClick" disabled="@_its.Inferring">
+        <i class="bi bi-card-checklist"></i> @_sln.Current?.ProjectName
+    </button>
+</Tooltip>

--- a/src/coding/src/dotnet/Cyrena.Dotnet.CSharp/Components/Shared/SolutionSelector.razor.cs
+++ b/src/coding/src/dotnet/Cyrena.Dotnet.CSharp/Components/Shared/SolutionSelector.razor.cs
@@ -1,33 +1,41 @@
-﻿using Cyrena.Contracts;
+﻿using BootstrapBlazor.Components;
+using Cyrena.Attributes;
+using Cyrena.Contracts;
 using Cyrena.Dotnet.Contracts;
+using Microsoft.AspNetCore.Components;
 
 namespace Cyrena.Dotnet.CSharp.Components.Shared
 {
     public partial class SolutionSelector
     {
-        private ISolutionController _sln = default!;
-        private IIterationService _its = default!;
-        private string _sln_id { get; set; } = default!;
+        [Inject] private DialogService _dialog { get; set; } = default!;
+        [KernelInject] private ISolutionController _sln { get; set; } = default!;
+        [KernelInject] private IIterationService _its { get; set; } = default!;
         protected override void OnInitialized()
         {
-            _sln = Kernel.GetRequiredService<ISolutionController>();
-            _its = Kernel.GetRequiredService<IIterationService>();
             _its.OnIterationStart(e => this.InvokeAsync(StateHasChanged));
             _its.OnIterationEnd(e => this.InvokeAsync(StateHasChanged));
-            _sln_id = _sln.Current.Id;
             _sln.OnProjectChange(p =>
             {
-                _sln_id = _sln.Current.Id;
                 this.InvokeAsync(StateHasChanged);
             });
         }
 
-        private async Task OnValueChange()
+        private async Task OnClick()
         {
-            if (_its.Inferring) return;
-            var proj = _sln.GetValidProjects().FirstOrDefault(x => x.Id == _sln_id);
-            if (proj != null) 
-                await _sln.SetTargetProject(proj);
+            if (_its.Inferring)
+                return;
+            var result = await _dialog.ShowModal<SolutionViewer>(new ResultDialogOption()
+            {
+                Size = Size.Medium,
+                Title = "Projects",
+                ShowNoButton = false,
+                ButtonYesText = "Done",
+                ComponentParameters = new()
+                {
+                    {nameof(SolutionViewer.Kernel), Kernel }
+                }
+            });
         }
     }
 }

--- a/src/coding/src/dotnet/Cyrena.Dotnet.CSharp/Components/Shared/SolutionViewer.razor
+++ b/src/coding/src/dotnet/Cyrena.Dotnet.CSharp/Components/Shared/SolutionViewer.razor
@@ -1,0 +1,29 @@
+﻿@inherits KernelComponentBase
+
+<div class="overflow-auto" style="max-height:50vh">
+    @foreach (var item in _sln.GetAllProjects())
+    {
+        <div class="mb-2 p-2 rounded border d-flex">
+            <div>
+                <p class="m-0 text-truncate">@item.ProjectName</p>
+                <select class="form-select form-select-sm" @bind="item.ProjectTypeId" @bind:after="() => Override(item)">
+                    <option value="">Hidden</option>
+                    @foreach(var proj in _projects)
+                    {
+                        <option value="@proj.Id">@proj.ProjectTypeName</option>
+                    }
+                </select>
+            </div>
+            <div class="justify-content-center align-self-center ms-auto">
+                @if (!string.IsNullOrEmpty(item.ProjectTypeId) && _sln.Current.Id != item.Id)
+                {
+                    <Tooltip Title="Set Active">
+                        <button type="button" class="btn btn-sm btn-primary rounded-pill" @onclick="() => SetActive(item)">
+                            <i class="bi bi-check2-square"></i>
+                        </button>
+                    </Tooltip>
+                }
+            </div>
+        </div>
+    }
+</div>

--- a/src/coding/src/dotnet/Cyrena.Dotnet.CSharp/Components/Shared/SolutionViewer.razor.cs
+++ b/src/coding/src/dotnet/Cyrena.Dotnet.CSharp/Components/Shared/SolutionViewer.razor.cs
@@ -1,0 +1,45 @@
+﻿using BootstrapBlazor.Components;
+using Cyrena.Attributes;
+using Cyrena.Dotnet.Contracts;
+using Cyrena.Dotnet.Models;
+using Microsoft.AspNetCore.Components;
+
+namespace Cyrena.Dotnet.CSharp.Components.Shared
+{
+    public partial class SolutionViewer : IResultDialog
+    {
+        [Inject] private ToastService _toasts { get; set; } = default!;
+        [KernelInject] private ISolutionController _sln { get; set; } = default!;
+        [KernelInject] private IEnumerable<IDotnetProjectType> _projects { get; set; } = default!;
+
+        public Task OnClose(DialogResult result)
+        {
+            return Task.CompletedTask;
+        }
+
+        private async Task SetActive(ProjectModel item)
+        {
+            try
+            {
+                await _sln.SetTargetProject(item);
+                this.StateHasChanged();
+            }catch (Exception ex)
+            {
+                await _toasts.Error(ex.Message);
+            }
+        }
+
+        private async Task Override(ProjectModel item)
+        {
+            try
+            {
+                await _sln.OverrideProjectType(item.Id, item.ProjectTypeId);
+                this.StateHasChanged();
+            }
+            catch(Exception ex)
+            {
+                await _toasts.Error(ex.Message);
+            }
+        }
+    }
+}

--- a/src/coding/src/dotnet/Cyrena.Dotnet.CSharp/Services/DevelopPlanIndexer.cs
+++ b/src/coding/src/dotnet/Cyrena.Dotnet.CSharp/Services/DevelopPlanIndexer.cs
@@ -38,12 +38,13 @@ namespace Cyrena.Dotnet.CSharp.Services
             var info = SolutionParser.GetProjectDetails(absolute_sln_path);
             var sln_dir = Path.GetDirectoryName(absolute_sln_path);
             var current_id = _sln.Current.Id;
-            _sln.Sln.Projects.Clear();
+            var models = new List<ProjectModel>();
             foreach (var item in info)
             {
-                var project_type = _project_types.FirstOrDefault(x => x.IsOfType(item));
                 var fi = new FileInfo(item.AbsolutePath);
                 var id = $"{fi.DirectoryName?.Replace(sln_dir ?? "", "").Replace("\\", "_")}_{item.ProjectName}";
+                var ext = _sln.Sln.Projects.FirstOrDefault(x => x.Id == id);
+                var project_type = _project_types.FirstOrDefault(x => x.Id == ext?.ProjectTypeId || x.IsOfType(item));
                 ProjectModel project = new ProjectModel()
                 {
                     ConversationId = _config.Config.Id,
@@ -52,9 +53,9 @@ namespace Cyrena.Dotnet.CSharp.Services
                     ProjectDirectory = fi.DirectoryName!,
                     ProjectTypeId = project_type?.Id,
                     ProjectTypeName = project_type?.ProjectTypeName,
-                    Id = $"{fi.DirectoryName?.Replace(sln_dir ?? "", "").Replace("\\", "_")}_{item.ProjectName}"
+                    Id = id
                 };
-                _sln.Sln.Projects.Add(project);
+                models.Add(project);
 
                 if (project_type != null)
                 {
@@ -63,6 +64,8 @@ namespace Cyrena.Dotnet.CSharp.Services
                     project_type.IndexPlan(project);
                 }
             }
+            _sln.Sln.Projects.Clear();
+            _sln.Sln.Projects.AddRange(models);
             var new_current = _sln.GetValidProjects().FirstOrDefault(x => x.Id == current_id);
             if(new_current != null)
             {

--- a/src/coding/src/dotnet/Cyrena.Dotnet.CSharp/Services/SolutionBuilder.cs
+++ b/src/coding/src/dotnet/Cyrena.Dotnet.CSharp/Services/SolutionBuilder.cs
@@ -13,6 +13,7 @@ using Cyrena.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Cyrena.Dotnet.Extensions;
+using Cyrena.Persistence.Options;
 
 namespace Cyrena.Dotnet.CSharp.Services
 {
@@ -59,29 +60,30 @@ namespace Cyrena.Dotnet.CSharp.Services
                 {
                     project.ProjectTypeId = project_type.Id;
                     project.ProjectTypeName = project_type.ProjectTypeName;
-                    project_type.IndexPlan(project);
+                    //project_type.IndexPlan(project); //Index later on in DevelopPlanIndexer, no need to do it here
                 }
             }
             var sln_model = new SolutionViewModel(options.ChatConfiguration.WorkingDirectory!);
             sln_model.Projects.AddRange(projects);
-            if(sln_model.Projects.Where(x => x.Plan != null).Count() == 0)
+            if (sln_model.Projects.Count == 0)
                 throw new InvalidOperationException($"Solution requires at least one supported project");
             ProjectModel active;
             if (string.IsNullOrEmpty(options.ChatConfiguration[DotnetOptions.LastProject]))
-                active = sln_model.Projects.FirstOrDefault(x => x.Plan != null)!;
+                active = sln_model.Projects.OrderBy(x => x.Plan != null).FirstOrDefault()!;
             else
             {
                 var act_t = sln_model.Projects.FirstOrDefault(x => x.Id == options.ChatConfiguration[DotnetOptions.LastProject]);
-                if(act_t == null || act_t.Plan == null)
-                    active = sln_model.Projects.FirstOrDefault(x => x.Plan != null)!;
+                if(act_t == null)
+                    active = sln_model.Projects.OrderBy(x => x.Plan != null).FirstOrDefault()!;
                 else
                     active = act_t;
             }
 
             options.ChatConfiguration[DotnetOptions.LastProject] = active.Id;
+            var persistence = options.GetFeatureOption<ICyrenaPersistenceBuilder>();
             options.Services.AddSingleton(sln_model);
             options.Services.AddSingleton(project_types);
-            options.AddSolutionController();
+            options.AddSolutionControllerWithProjectOverride();
             options.Plugins.AddFromType<DotnetSolution>();
             options.Plugins.AddFromType<DotnetTools>();
             options.Plugins.AddFromType<Blazor>();

--- a/src/coding/src/dotnet/Cyrena.Dotnet.CSharp/extension.json
+++ b/src/coding/src/dotnet/Cyrena.Dotnet.CSharp/extension.json
@@ -1,7 +1,7 @@
 {
   "id": "cyrena.dotnet.csharp",
   "name": ".NET Development (C#)",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "entryAssemblyFile": "Cyrena.Dotnet.CSharp.dll",
   "description": "Builds .NET C# projects and solutions with a strictly enforced structure. All supported project types share a common base layout (Attributes, Contracts, Extensions, Models, Services, Options) with per-type additions for Blazor (Components, wwwroot) and MVC (Controllers, Views, wwwroot). In solution mode, only supported project types are indexed — unsupported projects are ignored rather than blocked. Project and solution descriptor files (.csproj, .sln, .slnx) and JSON configuration files are read-only to the agent and will never be modified.",
   "dependencies": [

--- a/src/coding/src/dotnet/Cyrena.Dotnet.Core/Contracts/ISolutionController.cs
+++ b/src/coding/src/dotnet/Cyrena.Dotnet.Core/Contracts/ISolutionController.cs
@@ -9,9 +9,10 @@ namespace Cyrena.Dotnet.Contracts
     {
         Task SetTargetProject(ProjectModel current);
         IEnumerable<ProjectModel> GetValidProjects();
-        void RefreshProjectPlans();
         ProjectModel Current { get; }
         SolutionViewModel Sln { get; }
         IDisposable OnProjectChange(Action<ProjectModel> cb);
+        IEnumerable<ProjectModel> GetAllProjects();
+        Task OverrideProjectType(string projectId, string? projectTypeId);
     }
 }

--- a/src/coding/src/dotnet/Cyrena.Dotnet.Core/Cyrena.Dotnet.Core.csproj
+++ b/src/coding/src/dotnet/Cyrena.Dotnet.Core/Cyrena.Dotnet.Core.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Cyrena.Coding.Core" />
+    <PackageReference Include="Cyrena.Persistence.Core" />
   </ItemGroup>
 
 </Project>

--- a/src/coding/src/dotnet/Cyrena.Dotnet.Core/Extensions/CyrenaKernelBuilderExtensions.cs
+++ b/src/coding/src/dotnet/Cyrena.Dotnet.Core/Extensions/CyrenaKernelBuilderExtensions.cs
@@ -1,6 +1,9 @@
 ﻿using Cyrena.Dotnet.Contracts;
+using Cyrena.Dotnet.Models;
 using Cyrena.Dotnet.Services;
+using Cyrena.Extensions;
 using Cyrena.Models;
+using Cyrena.Persistence.Options;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Cyrena.Dotnet.Extensions
@@ -10,6 +13,14 @@ namespace Cyrena.Dotnet.Extensions
         public static void AddSolutionController(this CyrenaKernelBuilder builder)
         {
             builder.Services.AddSingleton<ISolutionController, SolutionController>();
+        }
+
+        public static void AddSolutionControllerWithProjectOverride(this CyrenaKernelBuilder builder)
+        {
+            var persistence = builder.GetFeatureOption<ICyrenaPersistenceBuilder>();
+            persistence.AddSingletonStore<ProjectTypeOverride>("project-config");
+            builder.Services.AddSingleton<ISolutionController, SolutionControllerOverride>();
+            builder.KernelBuilder.AddStartupTask<SolutionOverrideStartupTask>();
         }
     }
 }

--- a/src/coding/src/dotnet/Cyrena.Dotnet.Core/Models/ProjectTypeOverride.cs
+++ b/src/coding/src/dotnet/Cyrena.Dotnet.Core/Models/ProjectTypeOverride.cs
@@ -1,0 +1,18 @@
+﻿using Cyrena.Models;
+
+namespace Cyrena.Dotnet.Models
+{
+    public sealed class ProjectTypeOverride : Entity
+    {
+        [System.Text.Json.Serialization.JsonConstructor]
+        [Newtonsoft.Json.JsonConstructor]
+        internal ProjectTypeOverride() { }
+
+        public ProjectTypeOverride(string projectId)
+        {
+            Id = projectId;
+        }
+
+        public string? ProjectTypeId { get; set; }
+    }
+}

--- a/src/coding/src/dotnet/Cyrena.Dotnet.Core/Services/SolutionController.Override.cs
+++ b/src/coding/src/dotnet/Cyrena.Dotnet.Core/Services/SolutionController.Override.cs
@@ -1,0 +1,127 @@
+﻿using Cyrena.Coding.Contracts;
+using Cyrena.Contracts;
+using Cyrena.Dotnet.Contracts;
+using Cyrena.Dotnet.Models;
+using Cyrena.Dotnet.Options;
+using Cyrena.Extensions;
+using Cyrena.Models;
+using Cyrena.Persistence.Contracts;
+
+namespace Cyrena.Dotnet.Services
+{
+    internal class SolutionControllerOverride : ISolutionController
+    {
+        private readonly IStore<ProjectTypeOverride> _store;
+        private readonly IChatConfigurationService _config;
+        private readonly IEnumerable<IDotnetProjectType> _project_types;
+        private readonly IDevelopPlanService _plan;
+        private readonly SolutionViewModel _sln;
+        private readonly SolutionPipeline _pipe;
+        public SolutionControllerOverride(IStore<ProjectTypeOverride> store, IChatConfigurationService config, IEnumerable<IDotnetProjectType> project_types, IDevelopPlanService plan, SolutionViewModel sln)
+        {
+            _store = store;
+            _config = config;
+            _project_types = project_types;
+            _plan = plan;
+            _sln = sln;
+            _current = _sln.Projects.First(x => x.Id == _config.Config[DotnetOptions.LastProject])!;
+            _pipe = new SolutionPipeline();
+        }
+
+        private ProjectModel _current { get; set; } = default!;
+
+        public async Task SetTargetProject(ProjectModel current)
+        {
+            if (current.Plan == null)
+            {
+                var proj_type = _project_types.FirstOrDefault(x => x.Id == current.ProjectTypeId);
+                if (proj_type == null)
+                    throw new InvalidOperationException($"{current.Id} is unknown project type");
+                proj_type.IndexPlan(current);
+            }
+            _current = current;
+            _plan.SetPlan(current.Plan!);
+            _config.Config[DotnetOptions.LastProject] = current.Id;
+            _pipe.InvokeProjectChange(_current);
+            await _config.SaveConfigurationAsync();
+        }
+
+        public IEnumerable<ProjectModel> GetValidProjects()
+        {
+            return _sln.Projects.Where(x => x.Plan != null);
+        }
+
+        public IEnumerable<ProjectModel> GetAllProjects()
+        {
+            return _sln.Projects;
+        }
+
+        public IDisposable OnProjectChange(Action<ProjectModel> cb) => _pipe.WatchProjectChange(cb);
+
+        public ProjectModel Current => _current;
+        public SolutionViewModel Sln => _sln;
+
+        public void Dispose()
+        {
+            _pipe.Dispose();
+        }
+
+        public void RefreshProjectPlans()
+        {
+            foreach (var project in _sln.Projects)
+            {
+                var type = _project_types.FirstOrDefault(x => x.Id == project.ProjectTypeId);
+                if (type != null)
+                    type.IndexPlan(project);
+            }
+        }
+
+        public async Task OverrideProjectType(string projectId, string? projectTypeId)
+        {
+            var project = _sln.Projects.FirstOrDefault(x => x.Id == projectId);
+            if(project == null)
+                throw new NullReferenceException($"Unable to find project {projectId}");
+            var project_type = _project_types.FirstOrDefault(x => x.Id == projectTypeId);
+            if (!string.IsNullOrEmpty(projectTypeId) && project_type == null)
+                throw new NullReferenceException($"Unable to find project type indexer {projectTypeId}");
+
+            var ext = await _store.FindAsync(x => x.Id == projectId);
+            if(ext == null)
+                ext = new ProjectTypeOverride(projectId);
+            ext.ProjectTypeId = projectTypeId;
+            await _store.SaveAsync(ext);
+            if (project_type != null)
+                project_type.IndexPlan(project);
+            else
+                project.Plan = null;
+        }
+
+        internal async Task ApplyOverrides(CancellationToken ct = default!)
+        {
+            var ovrs = await _store.FindManyAsync(x => true, ct:ct);
+            foreach(var item in _sln.Projects)
+            {
+                var ovr = ovrs.FirstOrDefault(x => x.Id == item.Id);
+                if(ovr != null)
+                    item.ProjectTypeId = ovr.ProjectTypeId;
+            }
+        }
+    }
+
+    internal class SolutionOverrideStartupTask : IStartupTask
+    {
+        private readonly ISolutionController _sln;
+        public SolutionOverrideStartupTask(ISolutionController sln)
+        {
+            _sln = sln;
+        }
+
+        public int Order => 10;
+
+        public async Task RunAsync(CancellationToken cancellationToken = default)
+        {
+            if (_sln is SolutionControllerOverride ovr)
+                await ovr.ApplyOverrides(cancellationToken);
+        }
+    }
+}

--- a/src/coding/src/dotnet/Cyrena.Dotnet.Core/Services/SolutionController.Pipeline.cs
+++ b/src/coding/src/dotnet/Cyrena.Dotnet.Core/Services/SolutionController.Pipeline.cs
@@ -1,0 +1,11 @@
+﻿using Cyrena.Dotnet.Models;
+using Cyrena.Models;
+
+namespace Cyrena.Dotnet.Services
+{
+    internal class SolutionPipeline : EventPipeline
+    {
+        public IDisposable WatchProjectChange(Action<ProjectModel> callback) => this.ConfigurePipe("proj_change", callback);
+        public void InvokeProjectChange(ProjectModel proj) => this.InvokePipeline("proj_change", proj);
+    }
+}

--- a/src/coding/src/dotnet/Cyrena.Dotnet.Core/Services/SolutionController.cs
+++ b/src/coding/src/dotnet/Cyrena.Dotnet.Core/Services/SolutionController.cs
@@ -42,6 +42,11 @@ namespace Cyrena.Dotnet.Services
             return _sln.Projects.Where(x => x.Plan != null);
         }
 
+        public IEnumerable<ProjectModel> GetAllProjects()
+        {
+            return _sln.Projects;
+        }
+
         public IDisposable OnProjectChange(Action<ProjectModel> cb) => _pipe.WatchProjectChange(cb);
 
         public ProjectModel Current => _current;
@@ -62,10 +67,9 @@ namespace Cyrena.Dotnet.Services
             }
         }
 
-        internal class SolutionPipeline : EventPipeline
+        public Task OverrideProjectType(string projectId, string? projectTypeId)
         {
-            public IDisposable WatchProjectChange(Action<ProjectModel> callback) => this.ConfigurePipe("proj_change", callback);
-            public void InvokeProjectChange(ProjectModel proj) => this.InvokePipeline("proj_change", proj);
+            throw new NotImplementedException("Cannot override project type in project mode");
         }
     }
 }

--- a/tests/dotnet/slnx/.cyrena/project-config/_MyBlazorApp_MyBlazorApp.json
+++ b/tests/dotnet/slnx/.cyrena/project-config/_MyBlazorApp_MyBlazorApp.json
@@ -1,0 +1,1 @@
+{"ProjectTypeId":"cs-blazor-app","Id":"_MyBlazorApp_MyBlazorApp"}

--- a/tests/dotnet/slnx/.cyrena/project-config/_MyClassLibrary_MyClassLibrary.json
+++ b/tests/dotnet/slnx/.cyrena/project-config/_MyClassLibrary_MyClassLibrary.json
@@ -1,0 +1,1 @@
+{"ProjectTypeId":"cs-class-library","Id":"_MyClassLibrary_MyClassLibrary"}

--- a/tests/dotnet/slnx/.cyrena/project-config/_MyRazorLibrary_MyRazorLibrary.json
+++ b/tests/dotnet/slnx/.cyrena/project-config/_MyRazorLibrary_MyRazorLibrary.json
@@ -1,0 +1,1 @@
+{"ProjectTypeId":"cs-mvc-lib","Id":"_MyRazorLibrary_MyRazorLibrary"}


### PR DESCRIPTION
supports per-project visibility and project type overrides in *Solution* mode, allowing users to correct detected project types or hide projects from AI context entirely.
<img width="963" height="683" alt="image" src="https://github.com/user-attachments/assets/f7416b50-3f6a-4f79-92b8-022056784bc7" />
